### PR TITLE
Swap dip switch settings to match gmmk3 75 keyboard

### DIFF
--- a/keyboards/gmmk/gmmk3/p75/ansi/keymaps/default/keymap.c
+++ b/keyboards/gmmk/gmmk3/p75/ansi/keymaps/default/keymap.c
@@ -93,11 +93,11 @@ bool dip_switch_update_user(uint8_t index, bool active) {
 
     if (index == 0) {
         if (active){
-            layer_off(WIN_BL);
-            layer_on(MACOS_BL);
-        } else {
             layer_off(MACOS_BL);
             layer_on(WIN_BL);
+        } else {
+            layer_off(WIN_BL);
+            layer_on(MACOS_BL);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The dip switch settings for the gmmk3 75% ANSI keyboard are reversed compared to
other keymaps in the series. This results in the wrong behavior when using the keyboard
switch.

<!--- Describe your changes in detail here. -->

## Switched the statements in the dip switch condition to match the other keymaps

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Swapped OS switch behavior where ALT acts as the Windows key in MS Windows.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
